### PR TITLE
支持传入任意方式的健康检查方式，比如TCP/Http不受限于 consul.Register

### DIFF
--- a/cloud/service_instance.go
+++ b/cloud/service_instance.go
@@ -29,6 +29,8 @@ type ServiceInstance interface {
 
 	// return The key / value pair metadata associated with the service instance.
 	GetMetadata() map[string]string
+
+	GetCheck() *api.AgentServiceCheck
 }
 
 /**
@@ -41,6 +43,7 @@ type DefaultServiceInstance struct {
 	Port       int
 	Secure     bool
 	Metadata   map[string]string
+	Check      *api.AgentServiceCheck
 }
 
 /**
@@ -86,4 +89,8 @@ func (serviceInstance DefaultServiceInstance) IsSecure() bool {
 
 func (serviceInstance DefaultServiceInstance) GetMetadata() map[string]string {
 	return serviceInstance.Metadata
+}
+
+func (serviceInstance DefaultServiceInstance) GetCheck() *api.AgentServiceCheck {
+	return serviceInstance.Check
 }

--- a/cloud/serviceregistry/consul_service_registry.go
+++ b/cloud/serviceregistry/consul_service_registry.go
@@ -68,16 +68,16 @@ func (c consulServiceRegistry) Register(serviceInstance cloud.ServiceInstance) b
 	registration.Address = serviceInstance.GetHost()
 
 	// 增加consul健康检查回调函数
-	check := new(api.AgentServiceCheck)
-
-	schema := "http"
-	if serviceInstance.IsSecure() {
-		schema = "https"
-	}
-	check.HTTP = fmt.Sprintf("%s://%s:%d/actuator/health", schema, registration.Address, registration.Port)
-	check.Timeout = "1s"
-	check.Interval = "3s"
-	check.DeregisterCriticalServiceAfter = "10s" // 故障检查失败30s后 consul自动将注册服务删除
+	//check := new(api.AgentServiceCheck)
+	check := cloud.ServiceInstance.GetCheck()
+	//schema := "http"
+	//if serviceInstance.IsSecure() {
+	//	schema = "https"
+	//}
+	//check.HTTP = fmt.Sprintf("%s://%s:%d/actuator/health", schema, registration.Address, registration.Port)
+	//check.Timeout = "1s"
+	//check.Interval = "3s"
+	//check.DeregisterCriticalServiceAfter = "10s" // 故障检查失败30s后 consul自动将注册服务删除
 	registration.Check = check
 
 	// 注册服务到consul


### PR DESCRIPTION
	modified:   cloud/service_instance.go
	modified:   cloud/serviceregistry/consul_service_registry.go

1、改写 consul.NewDefaultServiceInstance方法 返回的DefaultServiceInstance struct，增加Check Check *api.AgentServiceCheck
2、调用时 new(api.AgentServiceCheck) ，传入Check
3、在interface上绑定GetCheck()方法
4、改写ServiceInstance consul.Register 方法（基于ServiceInstance interface），接收传入*api.AgentServiceCheck 的对象
在原有提交*api.AgentServiceRegistration时，即可带入Check 指针值